### PR TITLE
Make tag allocator use pinned memory in Stencil

### DIFF
--- a/source/test/applications/Stencil/main.cpp
+++ b/source/test/applications/Stencil/main.cpp
@@ -80,6 +80,15 @@ int main(
   tbox::SAMRAIManager::initialize();
 
   /*
+   * Set tag allocator to use pinned memory.
+   */
+#if defined(HAVE_CUDA) || defined(HAVE_HIP)
+  umpire::ResourceManager& rm = umpire::ResourceManager::getInstance();
+  rm.makeAllocator<umpire::strategy::QuickPool>("samrai::tag_allocator",
+    rm.getAllocator(umpire::resource::Pinned));
+#endif
+
+  /*
    * Initialize SAMRAI, enable logging, and process command line.
    */
   tbox::SAMRAIManager::startup();


### PR DESCRIPTION
This switches the tag_allocator, the umpire allocator used for allocating SAMRAI's tag data, from the default host memory to pinned memory.  As pinned memory it can be used within GPU kernels.